### PR TITLE
Florida region is ssl now

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CHANGELIST
 ***Version 1.2.8* ** *- October 5, 2018*
 
 - Carolina Region is now SSL.
+- Florida Region is now SSL.
 
 ***Version 1.2.7* ** *- September 2, 2018*
 

--- a/rootServerList.json
+++ b/rootServerList.json
@@ -19,7 +19,7 @@
 {"id":"120","name":"NA New Jersey","rootURL":"https://www.narcoticsanonymousnj.org/main_server/"},
 {"id":"121","name":"Connecticut Region","rootURL":"http://ctna.org/main_server/"},
 {"id":"122","name":"Volunteer Region","rootURL":"https://natennessee.org/main_server/"},
-{"id":"123","name":"Florida Region","rootURL":"http://naflorida.org/bmlt_server/"},
+{"id":"123","name":"Florida Region","rootURL":"https://naflorida.org/bmlt_server/"},
 {"id":"124","name":"NA Australia","rootURL":"https://www.na.org.au/main_server/"},
 {"id":"125","name":"Carolina Region","rootURL":"https://www.crna.org/main_server/"},
 {"id":"126","name":"NA Sweden","rootURL":"https://www.nasverige.org/main_server/"},


### PR DESCRIPTION
florida region has been ssl for a few weeks now. not sure that i should do version bump idk. https://www.sjna.org/main_server/semantic/ appears to be ssl as it works but also not sure we should add that without confirmation form them idk. I don't know alot, but jonathan and i helped ezra get on board with ssl a couple weeks ago